### PR TITLE
Chore: sort proxies ascending by default

### DIFF
--- a/src/containers/Proxies/index.tsx
+++ b/src/containers/Proxies/index.tsx
@@ -39,7 +39,7 @@ export default function Proxies () {
     }
 
     const { current: sort, next } = useRound(
-        [sortType.None, sortType.Asc, sortType.Desc]
+        [sortType.Asc, sortType.Desc, sortType.None]
     )
     const proxies = useMemo(() => {
         switch (sort) {


### PR DESCRIPTION
hope to change the default sort type to ascending.
I think an ascending order by proxies delay is more in line with most people's usage habits.