### PR TITLE
Fix CORS error in https dashboard with http api

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -12,12 +12,14 @@ interface ButtonProps extends BaseComponentProps {
 export function Button (props: ButtonProps) {
     const { type = 'normal', onClick = noop, children, className, style } = props
     const classname = classnames('button', `button-${type}`, className)
+    const buttonType = type === 'primary' ? 'submit' : 'button'
 
     return (
         <button
             className={classname}
             style={style}
             onClick={onClick}
+            type={buttonType}
         >{children}</button>
     )
 }

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -67,24 +67,26 @@ export function Modal (props: ModalProps) {
             ref={maskRef}
             onClick={handleMaskClick}
         >
-            <div
-                className={classnames('modal', `modal-${size}`, className)}
-                style={style}
-            >
-                <div className="modal-title">{title}</div>
+            <form>
                 <div
-                    className={classnames('modal-body', bodyClassName)}
-                    style={bodyStyle}
-                >{children}</div>
-                {
-                    footer && (
-                        <div className="footer">
-                            <Button onClick={() => onClose()}>取 消</Button>
-                            <Button type="primary" onClick={() => onOk()}>确 定</Button>
-                        </div>
-                    )
-                }
-            </div>
+                    className={classnames('modal', `modal-${size}`, className)}
+                    style={style}
+                >
+                    <div className="modal-title">{title}</div>
+                    <div
+                        className={classnames('modal-body', bodyClassName)}
+                        style={bodyStyle}
+                    >{children}</div>
+                    {
+                        footer && (
+                            <div className="footer">
+                                <Button onClick={() => onClose()}>取 消</Button>
+                                <Button type="primary" onClick={() => onOk()}>确 定</Button>
+                            </div>
+                        )
+                    }
+                </div>
+            </form>
         </div>
     )
 

--- a/src/containers/ExternalControllerDrawer/index.tsx
+++ b/src/containers/ExternalControllerDrawer/index.tsx
@@ -10,6 +10,7 @@ export default function ExternalController () {
     const { data: info, update, fetch } = containers.useAPIInfo()
     const { unauthorized: { hide, visible } } = containers.useData()
     const [value, set] = useObject({
+        protocol: '',
         hostname: '',
         port: '',
         secret: ''
@@ -20,12 +21,12 @@ export default function ExternalController () {
     }, [])
 
     useEffect(() => {
-        set({ hostname: info.hostname, port: info.port, secret: info.secret })
+        set({ protocol: info.protocol, hostname: info.hostname, port: info.port, secret: info.secret })
     }, [info])
 
     function handleOk () {
-        const { hostname, port, secret } = value
-        update({ hostname, port, secret })
+        const { protocol, hostname, port, secret } = value
+        update({ protocol, hostname, port, secret })
     }
 
     return (
@@ -40,6 +41,16 @@ export default function ExternalController () {
                 <p>{t('externalControllerSetting.note')}</p>
             </Alert>
             <Row gutter={24} align="middle">
+                <Col span={4} className="title">{t('externalControllerSetting.protocol')}</Col>
+                <Col span={20} className="form">
+                    <Input
+                        align="left"
+                        inside={true}
+                        value={value.protocol}
+                        onChange={protocol => set('protocol', protocol)}
+                    />
+                </Col>
+            </Row><Row gutter={24} align="middle">
                 <Col span={4} className="title">{t('externalControllerSetting.host')}</Col>
                 <Col span={20} className="form">
                     <Input

--- a/src/containers/ExternalControllerDrawer/index.tsx
+++ b/src/containers/ExternalControllerDrawer/index.tsx
@@ -80,6 +80,7 @@ export default function ExternalController () {
                         inside={true}
                         value={value.secret}
                         onChange={secret => set('secret', secret)}
+                        type="password"
                     />
                 </Col>
             </Row>

--- a/src/containers/Settings/index.tsx
+++ b/src/containers/Settings/index.tsx
@@ -79,6 +79,7 @@ export default function Settings () {
     }
 
     const {
+        protocol: externalControllerProtocol,
         hostname: externalControllerHost,
         port: externalControllerPort
     } = apiInfo
@@ -190,7 +191,7 @@ export default function Settings () {
                         </Col>
                         <Col className="external-controller" span={10}>
                             <span className="modify-btn" onClick={show}>
-                                {`${externalControllerHost}:${externalControllerPort}`}
+                                {`${externalControllerProtocol}//${externalControllerHost}:${externalControllerPort}`}
                             </span>
                         </Col>
                     </Col>

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -31,6 +31,7 @@ export default {
         externalControllerSetting: {
             title: 'External Controller',
             note: 'Please note that modifying this configuration will only configure Dashboard. Will not modify your Clash configuration file. Please make sure that the external controller address matches the address in the Clash configuration file, otherwise, Dashboard will not be able to connect to Clash.',
+            protocol: 'Protocol',
             host: 'Host',
             port: 'Port',
             secret: 'Secret'

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -31,6 +31,7 @@ export default {
         externalControllerSetting: {
             title: '编辑外部控制设置',
             note: '请注意，修改该配置项并不会修改你的 Clash 配置文件，请确认修改后的外部控制地址和 Clash 配置文件内的地址一致，否则会导致 Dashboard 无法连接。',
+            protocol: '协议',
             host: 'Host',
             port: '端口',
             secret: '密钥'

--- a/src/lib/jsBridge.ts
+++ b/src/lib/jsBridge.ts
@@ -139,7 +139,7 @@ export class JsBridge {
     }
 
     public getAPIInfo () {
-        return this.callHandler<{ host: string, port: string, secret: string }>('apiInfo')
+        return this.callHandler<{ protocol: string, host: string, port: string, secret: string }>('apiInfo')
     }
 
     public setPasteboard (data: string) {

--- a/src/lib/streamer.ts
+++ b/src/lib/streamer.ts
@@ -32,7 +32,7 @@ export class StreamReader<T> {
 
     protected websocketLoop () {
         const url = new URL(this.config.url)
-        url.protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'
+        url.protocol = url.protocol === 'http:' ? 'ws:' : 'wss:'
         url.searchParams.set('token', this.config.token)
 
         const connection = new WebSocket(url.toString())

--- a/src/models/Config.ts
+++ b/src/models/Config.ts
@@ -70,6 +70,7 @@ export interface ClashXData {
 }
 
 export interface APIInfo {
+    protocol: string
     hostname: string
     port: string
     secret?: string

--- a/src/stores/HookStore.ts
+++ b/src/stores/HookStore.ts
@@ -93,6 +93,7 @@ function useData () {
 
 function useAPIInfo () {
     const [data, set] = useObject<Models.APIInfo>({
+        protocol: 'http:',
         hostname: '127.0.0.1',
         port: '9090',
         secret: ''
@@ -104,7 +105,8 @@ function useAPIInfo () {
     }
 
     async function update (info: Models.APIInfo) {
-        const { hostname, port, secret } = info
+        const { protocol, hostname, port, secret } = info
+        setLocalStorageItem('externalControllerProtocol', protocol)
         setLocalStorageItem('externalControllerAddr', hostname)
         setLocalStorageItem('externalControllerPort', port)
         setLocalStorageItem('secret', secret)


### PR DESCRIPTION
- Fix CORS error in https dashboard with http api
- Use `password` input type for `secret` field for better detection by password manager