### PR TITLE
add reload config

### DIFF
--- a/src/containers/Settings/index.tsx
+++ b/src/containers/Settings/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
-import { Header, Card, Row, Col, Switch, ButtonSelect, ButtonSelectOptions, Input, Icon } from '@components'
+import { Header, Card, Row, Col, Switch, ButtonSelect, ButtonSelectOptions, Input, Icon, Button, showMessage } from '@components'
 import { useI18n, useClashXData, useAPIInfo, useGeneral, useIdentity } from '@stores'
-import { updateConfig } from '@lib/request'
+import { updateConfig, reloadConfig } from '@lib/request'
 import { useObject } from '@lib/hook'
 import { isClashX, jsBridge } from '@lib/jsBridge'
 import { Lang } from '@i18n'
@@ -66,6 +66,14 @@ export default function Settings () {
     async function handleAllowLanChange (state: boolean) {
         await updateConfig({ 'allow-lan': state })
         await fetchGeneral()
+    }
+    async function handleReloadConfig () {
+        let resp = await reloadConfig({})
+        if (resp.status === 204) {
+            showMessage({ content: t('reloadConfig.success'), type: "success" })
+        } else {
+            showMessage({ content: t('reloadConfig.fail'), type: "error" })
+        }
     }
 
     const {
@@ -184,6 +192,15 @@ export default function Settings () {
                             </span>
                         </Col>
                     </Col>
+                </Row>
+                <Row gutter={24} align="middle">
+                    <Col span={12}>
+                        <Col span={14} offset={1}>
+                            <Button type={"primary"} onClick={handleReloadConfig}>{t('reloadConfig.btn')}</Button>
+                        </Col>
+
+                    </Col>
+
                 </Row>
             </Card>
 

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -27,6 +27,11 @@ export default {
             rules: 'Rules',
             direct: 'Direct'
         },
+        reloadConfig:{
+            btn:'reload config',
+            success:'reload success',
+            fail:'reload fail'
+        },
         versionString: 'Current ClashX is the latest version：{{version}}',
         checkUpdate: 'Check Update',
         externalControllerSetting: {

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -27,6 +27,12 @@ export default {
             rules: '规则',
             direct: '直连'
         },
+        reloadConfig:{
+            btn:'重载配置',
+            success:'重载成功',
+            fail:'重载失败'
+        },
+
         versionString: '当前 ClashX 已是最新版本：{{version}}',
         checkUpdate: '检查更新',
         externalControllerSetting: {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -13,6 +13,10 @@ export interface Config {
     mode: string
     'log-level': string
 }
+export interface ReloadConfig{
+    force:boolean
+    path:string
+}
 
 export interface Rules {
     rules: Rule[]
@@ -130,6 +134,10 @@ export async function getConfig () {
 export async function updateConfig (config: Partial<Config>) {
     const req = await getInstance()
     return req.patch<void>('configs', config)
+}
+export async function reloadConfig(params:Partial<ReloadConfig>){
+    const req= await getInstance()
+    return req.put<void>('configs',params)
 }
 
 export async function getRules () {


### PR DESCRIPTION
按照 https://clash.gitbook.io/  中的api ，增加配置重载功能。 clash 那边的代码我也发给PR。我测试重载工作正常。
没有增加版本兼容，如果老版本的clash 使用新版本的 clash-dashboard 那个按钮也会显示出来。 