### PR TITLE
Feature: add schema/path in settings

### DIFF
--- a/src/containers/ExternalControllerDrawer/index.tsx
+++ b/src/containers/ExternalControllerDrawer/index.tsx
@@ -12,7 +12,9 @@ export default function ExternalController () {
     const [value, set] = useObject({
         hostname: '',
         port: '',
-        secret: ''
+        secret: '',
+        path: '',
+        protocol: ''
     })
 
     useEffect(() => {
@@ -20,12 +22,12 @@ export default function ExternalController () {
     }, [])
 
     useEffect(() => {
-        set({ hostname: info.hostname, port: info.port, secret: info.secret })
+        set({ hostname: info.hostname, port: info.port, secret: info.secret, path: info.path, protocol: info.protocol })
     }, [info])
 
     function handleOk () {
-        const { hostname, port, secret } = value
-        update({ hostname, port, secret })
+        const { hostname, port, secret, path, protocol } = value
+        update({ hostname, port, secret, path, protocol })
     }
 
     return (
@@ -51,6 +53,17 @@ export default function ExternalController () {
                 </Col>
             </Row>
             <Row gutter={24} align="middle">
+                <Col span={4} className="title">{t('externalControllerSetting.protocol')}</Col>
+                <Col span={20} className="form">
+                    <Input
+                        align="left"
+                        inside={true}
+                        value={value.protocol}
+                        onChange={protocol => set('protocol', protocol)}
+                    />
+                </Col>
+            </Row>
+            <Row gutter={24} align="middle">
                 <Col span={4} className="title">{t('externalControllerSetting.port')}</Col>
                 <Col span={20} className="form">
                     <Input
@@ -69,6 +82,17 @@ export default function ExternalController () {
                         inside={true}
                         value={value.secret}
                         onChange={secret => set('secret', secret)}
+                    />
+                </Col>
+            </Row>
+            <Row gutter={24} align="middle">
+                <Col span={4} className="title">{t('externalControllerSetting.path')}</Col>
+                <Col span={20} className="form">
+                    <Input
+                        align="left"
+                        inside={true}
+                        value={value.path}
+                        onChange={path => set('path', path)}
                     />
                 </Col>
             </Row>

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -36,7 +36,9 @@ export default {
             note: 'Please note that modifying this configuration will only configure Dashboard. Will not modify your Clash configuration file. Please make sure that the external controller address matches the address in the Clash configuration file, otherwise, Dashboard will not be able to connect to Clash.',
             host: 'Host',
             port: 'Port',
-            secret: 'Secret'
+            secret: 'Secret',
+            path: 'Path',
+            protocol: 'Protocol'
         }
     },
     Logs: {

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -36,7 +36,9 @@ export default {
             note: '请注意，修改该配置项并不会修改你的 Clash 配置文件，请确认修改后的外部控制地址和 Clash 配置文件内的地址一致，否则会导致 Dashboard 无法连接。',
             host: 'Host',
             port: '端口',
-            secret: '密钥'
+            secret: '密钥',
+            path: '路径',
+            protocol: '协议'
         }
     },
     Logs: {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -115,7 +115,7 @@ export async function getExternalControllerConfig () {
     const hostname = getLocalStorageItem('externalControllerAddr', window.location.hostname)
     const port = getLocalStorageItem('externalControllerPort', window.location.port)
     const secret = getLocalStorageItem('secret', '')
-    const path = getLocalStorageItem('path', '')
+    const path = getLocalStorageItem('path', window.location.pathname)
     const protocol = getLocalStorageItem('protocol', window.location.protocol)
 
     if (!hostname || !port) {

--- a/src/stores/recoil.ts
+++ b/src/stores/recoil.ts
@@ -247,12 +247,18 @@ export function useClashXData () {
 
 export const apiData = atom({
     key: 'apiData',
-    default: {
+    default: isClashX() ? {
         hostname: '127.0.0.1',
         port: '9090',
         secret: '',
         path: '',
         protocol: ''
+    } : {
+        hostname: location.hostname,
+        port: location.port,
+        secret: '',
+        path: location.pathname,
+        protocol: location.protocol
     }
 })
 

--- a/src/stores/recoil.ts
+++ b/src/stores/recoil.ts
@@ -250,7 +250,9 @@ export const apiData = atom({
     default: {
         hostname: '127.0.0.1',
         port: '9090',
-        secret: ''
+        secret: '',
+        path: '',
+        protocol: ''
     }
 })
 
@@ -263,10 +265,12 @@ export function useAPIInfo () {
     }
 
     async function update (info: typeof data) {
-        const { hostname, port, secret } = info
+        const { hostname, port, secret, path, protocol } = info
         setLocalStorageItem('externalControllerAddr', hostname)
         setLocalStorageItem('externalControllerPort', port)
         setLocalStorageItem('secret', secret)
+        setLocalStorageItem('path', path)
+        setLocalStorageItem('protocol', protocol)
         window.location.reload()
     }
 


### PR DESCRIPTION
Added schema/path in settings - External controller, for use in the following scenario:
- Clash is running on a headless server
- External is behind a reverse proxy like nginx
- Due some limitations, clash api must be access in a subdirectory
