### PR TITLE
chore: replace onClick with onMouseDown for Modal

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -59,7 +59,7 @@ export function Modal (props: ModalProps) {
         return () => document.body.removeChild(portalRef.current)
     }, [])
 
-    function handleMaskClick (e: MouseEvent) {
+    function handleMaskMouseDown (e: MouseEvent) {
         if (e.target === maskRef.current) {
             onClose()
         }
@@ -69,7 +69,7 @@ export function Modal (props: ModalProps) {
         <div
             className={classnames('modal-mask', { 'modal-show': show })}
             ref={maskRef}
-            onClick={handleMaskClick}
+            onMouseDown={handleMaskMouseDown}
         >
             <div
                 className={classnames('modal', `modal-${size}`, className)}


### PR DESCRIPTION
External controller settings modal contains Input Components.

So if we do:
1. mouse down on input field to start the selection
2. release the mouse on mask
3. ``onClick`` fired
4. Modal closed