### PR TITLE
style: use overflow hidden to prevent the whole page from being scrolled

### DIFF
--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -5,6 +5,7 @@
 html {
     box-sizing: border-box;
     background: rgba($color: $color-white, $alpha: 0.8);
+    overflow: hidden;
 }
 
 *,


### PR DESCRIPTION
Right now if you try to scroll over the navigation bar, the whole page is pulled down, which makes the app feel unnatural. This PR uses `overflow: hidden` to solve this problem.

<img width="1032" alt="截圖 2020-11-16 21 22 18" src="https://user-images.githubusercontent.com/8423594/99261786-2650e180-2858-11eb-8c58-cee40e04045c.png">

Signed-off-by: imtsuki <me@qjx.app>