### PR TITLE
Show Process Name

### DIFF
--- a/src/containers/Connections/Info/index.tsx
+++ b/src/containers/Connections/Info/index.tsx
@@ -52,6 +52,10 @@ export function ConnectionInfo (props: ConnectionsInfoProps) {
                 }</span>
             </div>
             <div className="flex my-3">
+                <span className="w-14 font-bold">{t('info.processName')}</span>
+                <span className="font-mono">{props.connection.metadata?.processName}</span>
+            </div>
+            <div className="flex my-3">
                 <span className="w-14 font-bold">{t('info.rule')}</span>
                 <span className="font-mono">
                     { props.connection.rule && `${props.connection.rule}${props.connection.rulePayload && `(${props.connection.rulePayload})`}` }

--- a/src/containers/Connections/index.tsx
+++ b/src/containers/Connections/index.tsx
@@ -17,6 +17,7 @@ import './style.scss'
 
 enum Columns {
     Host = 'host',
+    ProcessName = 'processName',
     Network = 'network',
     Type = 'type',
     Chains = 'chains',
@@ -98,6 +99,7 @@ export default function Connections () {
             speed: { upload: c.uploadSpeed, download: c.downloadSpeed },
             completed: !!c.completed,
             original: c,
+            processName: c.metadata.processName,
         }),
     ), [connections])
     const devices = useMemo(() => {
@@ -110,6 +112,7 @@ export default function Connections () {
     const { x: scrollX } = useScroll(tableRef)
     const columns: Array<TableColumnOption<FormatConnection>> = useMemo(() => [
         { Header: t(`columns.${Columns.Host}`), accessor: Columns.Host, minWidth: 260, width: 260 },
+        { Header: t(`columns.${Columns.ProcessName}`), accessor: Columns.ProcessName, minWidth: 120, width: 120 },
         { Header: t(`columns.${Columns.Network}`), accessor: Columns.Network, minWidth: 80, width: 80 },
         { Header: t(`columns.${Columns.Type}`), accessor: Columns.Type, minWidth: 120, width: 120 },
         { Header: t(`columns.${Columns.Chains}`), accessor: Columns.Chains, minWidth: 200, width: 200 },

--- a/src/containers/Connections/store.ts
+++ b/src/containers/Connections/store.ts
@@ -14,6 +14,7 @@ export interface FormatConnection {
     type: string
     network: string
     sourceIP: string
+    processName: string
     speed: {
         upload: number
         download: number

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -93,6 +93,7 @@ const EN = {
             opening: 'Open',
             closed: 'Closed',
             closeConnection: 'Close',
+            processName: 'Process Name',
         },
     },
     Proxies: {

--- a/src/i18n/en_US.ts
+++ b/src/i18n/en_US.ts
@@ -66,6 +66,7 @@ const EN = {
         columns: {
             host: 'Host',
             network: 'Network',
+            processName: 'Process Name',
             type: 'Type',
             chains: 'Chains',
             rule: 'Rule',

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -93,6 +93,7 @@ const CN = {
             opening: '连接中',
             closed: '已关闭',
             closeConnection: '关闭连接',
+            processName: '进程名',
         },
     },
     Proxies: {

--- a/src/i18n/zh_CN.ts
+++ b/src/i18n/zh_CN.ts
@@ -66,6 +66,7 @@ const CN = {
         columns: {
             host: '域名',
             network: '网络',
+            processName: '进程名',
             type: '类型',
             chains: '节点链',
             rule: '规则',

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -84,6 +84,7 @@ export interface Connections {
         sourcePort: string
         destinationPort: string
         destinationIP?: string
+        processName: string
     }
     upload: number
     download: number


### PR DESCRIPTION
The process name is pretty useful for network proxy debugging and has been integrated in [proxifier](http://www.proxifier.com) and [surge](https://nssurge.com) long ago.

Clash, that clash-dashboard is based on, didn't provide an easy access to process name information.
However, a recent change https://github.com/Dreamacro/clash/pull/1486 unleash the potential to downstream softwares.

This PR modifies the UI to show the newly available information.
Modification 1: New column
<img width="920" alt="image" src="https://user-images.githubusercontent.com/85772926/125147891-7ee13180-e0fc-11eb-9f95-63b72c9ce235.png">
Modification 2: New item in info page
<img width="881" alt="image" src="https://user-images.githubusercontent.com/85772926/125147909-ae903980-e0fc-11eb-909c-99b6205c217f.png">

The previous demos run on MacOS with clashx.
The specific layout and style might not be optimal and is subject to change. We could also dream other functionality based on process name.
Finally, this PR must wait https://github.com/Dreamacro/clash/pull/1486 to be merged. 
